### PR TITLE
Corrected fine-tuning toggle on training page.

### DIFF
--- a/templates/training.html
+++ b/templates/training.html
@@ -254,7 +254,7 @@
       <div class="form-check">
         <input class="form-check-input" type="checkbox" value="True" name="fine_tuning" id="fine_tuning" onclick="fine_tuning_check()" >
         <input class="form-check-input" type="hidden" value="False" name="fine_tuning" id="fine_tuning_hidden" >
-        <label class="form-check-label" for="Zoom" >
+        <label class="form-check-label" for="fine_tuning" >
           Activate
         </label>
         </div>


### PR DESCRIPTION
Hitting "Activate" fine-tuning no longer toggles the zoom augmentation option.